### PR TITLE
Resolved issues with .KittyCard site structure after a recent update

### DIFF
--- a/src/js/app/KittyCard.js
+++ b/src/js/app/KittyCard.js
@@ -9,7 +9,7 @@ class KittyCard{
     }
 
     getSpeed(){
-        var speed = $(".KittyCard-coldown", this.getContainer()).text();
+        var speed = $(".KittyCard-details-item:eq(2)", this.getContainer()).text();
         speed = $.trim(speed).toLowerCase();
         return speed;
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -8,7 +8,7 @@ export default {
      */
     kittyCardToId: function($card) {
         var $parent = $card.closest(".KittyCard-wrapper"),
-            idText  = $(".KittyCard-subname", $parent).text(),
+            idText  = $(".KittyCard-details-item:eq(0)", $parent).text(),
             re      = /Kitty\s(\d+)/i;
 
         return this.regex.extractFirstMatch(re, idText)


### PR DESCRIPTION
Recent update has moved the Kitty data from `KittyCard-coldown` and `KittyCard-subname` into three separate attributes within the `KittyCard-details-item` items

To resolve this issue I've changed the `kittyCardToId` function to take the indexed 0 `KittyCard-details-item` item; and the `getSpeed` function now sources from index 2

I've deployed the extension locally and confirmed it no longer throws exceptions for `speed` and `rarity` not found.